### PR TITLE
Fix to prevent legend ID collisions

### DIFF
--- a/src/creator-store.js
+++ b/src/creator-store.js
@@ -54,7 +54,10 @@ const importFromQset = (qset) => {
 		}
 	})
 
-	legendIdIncrement = qset.options.legend.length
+	// sets legendIdIncrement to the highest existing id the qset: prevents an item from ever receiving a duplicate legend id
+	qset.options.legend.forEach((term) => {
+		if (term.id > legendIdIncrement) legendIdIncrement = term.id
+	})
 
 	return {
 		items: items,


### PR DESCRIPTION
The `legendIdIncrement` updates to the highest id value in the qset to make sure that the incremented values will never collide with existing values